### PR TITLE
Switch plugin to comment-experience instead of comment-hacks & more

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -56,6 +56,7 @@
 			<property name="prefixes" type="array">
 				<element value="EmiliaProjects\WP\Comment"/>
 				<element value="comment_hacks"/>
+				<element value="comment_experience"/>
 			</property>
 		</properties>
 	</rule>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	name="Comment Hacks"
+	name="Comment Experience"
 	xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
 
-	<description>Comment Hacks rules for PHP_CodeSniffer</description>
+	<description>Comment Experience rules for PHP_CodeSniffer</description>
 
 	<!--
 	#############################################################################

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -21,7 +21,7 @@ class Admin {
 	/**
 	 * The plugin page hook.
 	 */
-	private string $hook = 'comment-hacks';
+	private string $hook = 'comment-experience';
 
 	/**
 	 * Holds the plugins options.
@@ -59,9 +59,25 @@ class Admin {
 		\add_action( 'admin_head', [ $this, 'forward_comment' ] );
 		\add_filter( 'comment_text', [ $this, 'show_forward_status' ], 10, 2 );
 
+		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_discussion_settings_script' ] );
+
 		new Comment_Parent();
 	}
 
+	public function enqueue_discussion_settings_script( $hook ) {
+		if ( 'options-discussion.php' !== $hook ) {
+			return;
+		}
+	
+		wp_add_inline_script(
+			'jquery-core',
+			'jQuery(document).ready(function($){
+				var link = "<div style=\"margin: 15px 0;\"><strong>Note:</strong> You will find more comment settings on the <a href=\"' . admin_url('options-general.php?page=' . $this->hook ) . '\">Comment Experience plugin\'s settings page</a>.</div>";
+				$(".wrap > h1").after(link);
+			});'
+		);
+	}
+	
 	/**
 	 * Show when a comment was forwarded already.
 	 *
@@ -183,7 +199,7 @@ To: ' . \esc_html( \get_bloginfo( 'name' ) ) . ' &lt;' . \esc_html( $this->optio
 	public function register_meta_boxes(): void {
 		\add_meta_box(
 			'comment-hacks-reroute',
-			\__( 'Comment Hacks', 'comment-hacks' ),
+			\__( 'Comment Experience', 'comment-hacks' ),
 			[
 				$this,
 				'meta_box_callback',
@@ -263,7 +279,7 @@ To: ' . \esc_html( \get_bloginfo( 'name' ) ) . ' &lt;' . \esc_html( $this->optio
 	public function enqueue(): void {
 		$page = \filter_input( \INPUT_GET, 'page' );
 
-		if ( $page === 'comment-hacks' ) {
+		if ( $page === 'comment-experience' ) {
 			\wp_enqueue_style(
 				'emiliaprojects-comment-hacks-admin-css',
 				\plugins_url( 'admin/assets/css/comment-hacks.css', \EMILIA_COMMENT_HACKS_FILE ),
@@ -387,8 +403,8 @@ To: ' . \esc_html( \get_bloginfo( 'name' ) ) . ' &lt;' . \esc_html( $this->optio
 	 */
 	public function add_config_page() {
 		\add_options_page(
-			\__( 'Comment Hacks', 'comment-hacks' ),
-			\__( 'Comment Hacks', 'comment-hacks' ),
+			\__( 'Comment Experience', 'comment-hacks' ),
+			\__( 'Comment Experience', 'comment-hacks' ),
 			'manage_options',
 			$this->hook,
 			[

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -64,20 +64,27 @@ class Admin {
 		new Comment_Parent();
 	}
 
+	/**
+	 * Enqueue a small script on the discussion settings page to link to the comment experience settings page.
+	 *
+	 * @param string $hook The current admin page.
+	 *
+	 * @return void
+	 */
 	public function enqueue_discussion_settings_script( $hook ) {
-		if ( 'options-discussion.php' !== $hook ) {
+		if ( $hook !== 'options-discussion' ) {
 			return;
 		}
-	
-		wp_add_inline_script(
+
+		\wp_add_inline_script(
 			'jquery-core',
 			'jQuery(document).ready(function($){
-				var link = "<div style=\"margin: 15px 0;\"><strong>Note:</strong> You will find more comment settings on the <a href=\"' . admin_url('options-general.php?page=' . $this->hook ) . '\">Comment Experience plugin\'s settings page</a>.</div>";
+				var link = "<div style=\"margin: 15px 0;\"><strong>Note:</strong> You will find more comment settings on the <a href=\"' . \admin_url( 'options-general.php?page=' . $this->hook ) . '\">Comment Experience plugin\'s settings page</a>.</div>";
 				$(".wrap > h1").after(link);
 			});'
 		);
 	}
-	
+
 	/**
 	 * Show when a comment was forwarded already.
 	 *

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -72,7 +72,7 @@ class Admin {
 	 * @return void
 	 */
 	public function enqueue_discussion_settings_script( $hook ) {
-		if ( $hook !== 'options-discussion' ) {
+		if ( $hook !== 'options-discussion.php' ) {
 			return;
 		}
 

--- a/admin/assets/css/comment-hacks.css
+++ b/admin/assets/css/comment-hacks.css
@@ -1,16 +1,21 @@
 .emiliaprojectstab {
 	display: none;
-	margin-top :15px
-}
+	margin-top: 15px;
+	max-width: 800px;
 
-.emiliaprojectstab.active {
-	display: block
-}
+	&.active {
+		display: block
+	}
+	
+	strong {
+		font-size: 115%
+	}
+	
+	.dashicons-email-alt {
+		color:#00f
+	}
 
-.emiliaprojectstab strong {
-	font-size: 115%
-}
-
-.emiliaprojectstab .dashicons-email-alt {
-	color:#00f
+	table th {
+		width: 250px;
+	}
 }

--- a/admin/views/config-page.php
+++ b/admin/views/config-page.php
@@ -10,7 +10,7 @@ use EmiliaProjects\WP\Comment\Inc\Hacks;
 
 ?>
 	<div class="wrap">
-		<h2><?php esc_html_e( 'Comment Hacks', 'comment-hacks' ); ?></h2>
+		<h2><?php esc_html_e( 'Comment Experience', 'comment-hacks' ); ?></h2>
 
 		<h2 class="nav-tab-wrapper" id="emiliaprojects-tabs">
 			<a class="nav-tab nav-tab-active" id="comment-length-tab" href="#top#comment-length">
@@ -263,7 +263,7 @@ use EmiliaProjects\WP\Comment\Inc\Hacks;
 			<div id="comment-redirect" class="emiliaprojectstab">
 				<h3><?php esc_html_e( 'Redirect first time commenters', 'comment-hacks' ); ?></h3>
 
-				<p><?php esc_html_e( 'Select the page below that a first time commenter should be redirected to', 'comment-hacks' ); ?></p>
+				<p><?php esc_html_e( 'Select the page below that a first time commenter on your site should be redirected to.', 'comment-hacks' ); ?></p>
 				<table class="form-table">
 					<tr>
 						<th scope="row">
@@ -291,6 +291,44 @@ use EmiliaProjects\WP\Comment\Inc\Hacks;
 								<br>
 								<br>
 								<a target="_blank" href="<?php echo esc_url( get_permalink( (int) $this->options['redirect_page'] ) ); ?>">
+									<?php esc_html_e( 'Current redirect page', 'comment-hacks' ); ?>
+								</a>
+							<?php endif; ?>
+						</td>
+					</tr>
+				</table>
+
+				<h3><?php esc_html_e( 'Redirect repeat commenters', 'comment-hacks' ); ?></h3>
+
+				<p><?php esc_html_e( 'A repeat commenter is a commenter that has commented on your entire site more than once. Select the page below that they should be redirected to.', 'comment-hacks' ); ?></p>
+				<p><?php esc_html_e( 'Note that if you have the "Redirect first time commenters" option set to "Don\'t redirect first time commenters", and you do have a page selected here, first-time commenters will be redirected to the same page as repeat commenters.', 'comment-hacks' ); ?></p>
+				<table class="form-table">
+					<tr>
+						<th scope="row">
+							<label for="redirect_repeat_page">
+								<?php esc_html_e( 'Redirect repeat commenters to', 'comment-hacks' ); ?>
+							</label>
+						</th>
+						<td>
+							<?php
+							// A dropdown of all pages in the current WP install.
+							wp_dropdown_pages(
+								[
+									'depth'             => 0,
+									'id'                => 'redirect_repeat_page',
+									// phpcs:ignore WordPress.Security.EscapeOutput -- This is a hard-coded string, just passed around as a variable.
+									'name'              => Hacks::$option_name . '[redirect_repeat_page]',
+									'option_none_value' => '',
+									'selected'          => ( isset( $this->options['redirect_repeat_page'] ) ? (int) $this->options['redirect_repeat_page'] : 0 ),
+									'show_option_none'  => esc_html__( 'Don\'t redirect repeat commenters', 'comment-hacks' ),
+								]
+							);
+							?>
+
+							<?php if ( isset( $this->options['redirect_repeat_page'] ) && $this->options['redirect_repeat_page'] !== 0 ) : ?>
+								<br>
+								<br>
+								<a target="_blank" href="<?php echo esc_url( get_permalink( (int) $this->options['redirect_repeat_page'] ) ); ?>">
 									<?php esc_html_e( 'Current redirect page', 'comment-hacks' ); ?>
 								</a>
 							<?php endif; ?>
@@ -438,7 +476,7 @@ use EmiliaProjects\WP\Comment\Inc\Hacks;
 
 /**
  * Action hook to allow other plugins to add additional information to the
- * Comment Hacks admin page.
+ * Comment Experience admin page.
  *
  * @since 1.6.0
  */

--- a/comment-hacks.php
+++ b/comment-hacks.php
@@ -1,18 +1,18 @@
 <?php
 /**
- * Comment Hacks plugin.
+ * Comment Experience plugin.
  *
  * @wordpress-plugin
- * Plugin Name:  Comment Hacks
+ * Plugin Name:  Comment Experience
  * Version:      2.1.1
- * Plugin URI:   https://joost.blog/plugins/comment-hacks/
- * Description:  Make comments management easier by applying the simple hacks Joost has gathered over the years.
+ * Plugin URI:   https://progressplanner.com/plugins/comment-experience/
+ * Description:  Improve the comment experience on your site. Adds lots of features to make commenting easier and more engaging.
  * Requires PHP: 7.4
- * Author:       Joost de Valk
- * Author URI:   https://joost.blog/
+ * Author:       Team Progress Planner
+ * Author URI:   https://progressplanner.com
  * Text Domain:  comment-hacks
  *
- * Copyright 2009-2024 Joost de Valk (email: joost@joost.blog)
+ * Copyright 2009-2025 Joost de Valk and Team Progress Planner
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -234,11 +234,29 @@ class Hacks {
 				 *
 				 * @param string $url     URL to which the first-time commenter will be redirected.
 				 * @param object $comment The comment object.
+				 * @param string $type    The type of redirect.
 				 *
 				 * @since 1.6.0
 				 */
-				$url = \apply_filters( 'EmiliaProjects\WP\Comment\redirect', $url, $comment );
+				$url = \apply_filters( 'EmiliaProjects\WP\Comment\redirect', $url, $comment, 'first' );
 			}
+		}
+
+		// Only change $url when the page option is actually set and not zero.
+		if ( isset( $this->options['redirect_repeat_page'] ) && $this->options['redirect_repeat_page'] !== 0 ) {
+			$url = \get_permalink( (int) $this->options['redirect_repeat_page'] );
+
+			/**
+			 * Allow other plugins to hook in when the user is being redirected,
+			 * for analytics calls or even to change the target URL.
+			 *
+			 * @param string $url     URL to which a repeat commenter will be redirected.
+			 * @param object $comment The comment object.
+			 * @param string $type    The type of redirect.
+			 *
+			 * @since 2.2.0
+			 */
+			$url = \apply_filters( 'EmiliaProjects\WP\Comment\redirect', $url, $comment, 'repeat' );
 		}
 
 		return $url;

--- a/inc/progress-planner/comment-policy.php
+++ b/inc/progress-planner/comment-policy.php
@@ -51,7 +51,7 @@ class Comment_Policy extends One_Time {
 			\esc_html__( 'Implement a %s to make sure your commenters know what they can and cannot do.', 'comment-hacks' ),
 			'<a href="https://prpl.fyi/comment-policy" target="_blank">' . \esc_html__( 'comment policy', 'comment-hacks' ) . '</a>'
 		);
-		$this->url = \admin_url( 'options-general.php?page=comment-hacks#top#comment-policy' );
+		$this->url = \admin_url( 'options-general.php?page=comment-policy#top#comment-policy' );
 	}
 
 	/**

--- a/inc/progress-planner/comment-policy.php
+++ b/inc/progress-planner/comment-policy.php
@@ -84,7 +84,7 @@ class Comment_Policy extends One_Time {
 			'priority'     => 'high',
 			'type'         => $this->get_provider_type(),
 			'points'       => 1,
-			'url'          => $this->capability_required() ? \esc_url( \admin_url( 'options-general.php?page=comment-hacks#top#comment-policy' ) ) : '',
+			'url'          => $this->capability_required() ? \esc_url( \admin_url( 'options-general.php?page=comment-experience#top#comment-policy' ) ) : '',
 			'description'  => '<p>' . \sprintf(
 				/* translators: %s:<a href="https://prpl.fyi/comment-policy" target="_blank">comment policy</a> link */
 				\esc_html__( 'Implement a %s to make sure your commenters know what they can and cannot do.', 'comment-hacks' ),

--- a/inc/progress-planner/comment-redirect.php
+++ b/inc/progress-planner/comment-redirect.php
@@ -51,7 +51,7 @@ class Comment_Redirect extends One_Time {
 			\esc_html__( 'Implement a %s to thank first-time commenters for their comment.', 'comment-hacks' ),
 			'<a href="https://prpl.fyi/comment-policy" target="_blank">' . \esc_html__( 'comment redirect', 'comment-hacks' ) . '</a>'
 		);
-		$this->url = \admin_url( 'options-general.php?page=comment-hacks#top#comment-redirect' );
+		$this->url = \admin_url( 'options-general.php?page=comment-policy#top#comment-redirect' );
 	}
 
 	/**

--- a/inc/progress-planner/comment-redirect.php
+++ b/inc/progress-planner/comment-redirect.php
@@ -84,7 +84,7 @@ class Comment_Redirect extends One_Time {
 			'priority'     => 'high',
 			'type'         => $this->get_provider_type(),
 			'points'       => 1,
-			'url'          => $this->capability_required() ? \esc_url( \admin_url( 'options-general.php?page=comment-hacks#top#comment-redirect' ) ) : '',
+			'url'          => $this->capability_required() ? \esc_url( \admin_url( 'options-general.php?page=comment-experience#top#comment-redirect' ) ) : '',
 			'description'  => '<p>' . \sprintf(
 				/* translators: %s:<a href="https://prpl.fyi/comment-redirect" target="_blank">comment redirect</a> link */
 				\esc_html__( 'Implement a %s to thank first-time commenters for their comment.', 'comment-hacks' ),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comment-hacks",
-  "description": "Development files for the Comment Hacks plugin",
+  "description": "Development files for the Comment Experience plugin",
   "license": "GPL-2.0+",
   "plugin": {
     "glotpress": "https://translate.wordpress.org",

--- a/readme.md
+++ b/readme.md
@@ -4,13 +4,13 @@
 [![Release Version](https://img.shields.io/github/release/emilia-capital/comment-hacks.svg)](https://github.com/emilia-capital/comment-hacks/releases/latest) 
 [![MIT License](https://img.shields.io/github/license/emilia-capital/comment-hacks.svg)](https://github.com/emilia-capital/comment-hacks/blob/trunk/LICENSE)
 
-# Comment Hacks
+# Comment Experience by Progress Planner
 
-Make comments management easier by applying the simple hacks Joost has gathered over the years.
+Improve the comment experience on your site. Adds lots of features to make commenting easier and more engaging.
 
 ## Description
 
-This plugin adds some small hacks around core WordPress comments to make them more bearable:
+This plugin adds many small improvements around core WordPress comments to make them more bearable:
 
 * Cleaner comment notification emails.
 * The option to enforce a comment policy.

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Comment Hacks ===
+=== Comment Experience by Progress Planner ===
 Contributors: joostdevalk
 Tags: comments, spam, emails
 Text Domain: comment-hacks
@@ -47,7 +47,7 @@ If you have bugs to report, please go to [the plugin's GitHub repository](https:
 1. Download and unzip the plugin.
 1. Upload the `comment-hacks` directory to the `/wp-content/plugins/` directory.
 1. Activate the plugin through the 'Plugins' menu in WordPress.
-1. Configure your settings on the Settings &rarr; Comment Hacks screen.
+1. Configure your settings on the Settings &rarr; Comment Experience screen.
 
 == Screenshots ==
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,7 +9,7 @@ if ( \function_exists( 'xdebug_disable' ) ) {
 	\xdebug_disable();
 }
 
-echo 'Welcome to the Comment Hacks Test Suite' . \PHP_EOL;
+echo 'Welcome to the Comment Experience Test Suite' . \PHP_EOL;
 echo 'Version: 1.0' . \PHP_EOL . \PHP_EOL;
 
 require_once \dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This renames the plugin from "Comment Hacks" to "Comment Experience"
* Adds a link to the "Comment Experience" settings on the `options-discussion.php` settings page.
* Adds an option to redirect repeat commenters, just like first time commenters.

