### PR TITLE
Do not add PP providers if PP version is older than 1.1.1

### DIFF
--- a/inc/progress-planner-tasks.php
+++ b/inc/progress-planner-tasks.php
@@ -25,7 +25,7 @@ class Progress_Planner_Tasks {
 	 */
 	public function add_task_providers( $providers ) {
 		// Bail early if the version is less than 1.1.1.
-		$progress_planner_version = \get_file_data( PROGRESS_PLANNER_FILE, [ 'Version' => 'Version' ] )['Version'];
+		$progress_planner_version = \get_file_data( \PROGRESS_PLANNER_FILE, [ 'Version' => 'Version' ] )['Version'];
 		if ( \version_compare( $progress_planner_version, '1.1.1', '<' ) ) {
 			return $providers;
 		}

--- a/inc/progress-planner-tasks.php
+++ b/inc/progress-planner-tasks.php
@@ -24,11 +24,6 @@ class Progress_Planner_Tasks {
 	 * @return array<int,Provider> Array of task provider objects.
 	 */
 	public function add_task_providers( $providers ) {
-		// Get the version of the PROGRESS_PLANNER_FILE file.
-		if ( ! defined( 'PROGRESS_PLANNER_FILE' ) ) {
-			return $providers;
-		}
-
 		// Bail early if the version is less than 1.1.1.
 		$progress_planner_version = \get_file_data( PROGRESS_PLANNER_FILE, [ 'Version' => 'Version' ] )['Version'];
 		if ( \version_compare( $progress_planner_version, '1.1.1', '<' ) ) {

--- a/inc/progress-planner-tasks.php
+++ b/inc/progress-planner-tasks.php
@@ -24,6 +24,17 @@ class Progress_Planner_Tasks {
 	 * @return array<int,Provider> Array of task provider objects.
 	 */
 	public function add_task_providers( $providers ) {
+		// Get the version of the PROGRESS_PLANNER_FILE file.
+		if ( ! defined( 'PROGRESS_PLANNER_FILE' ) ) {
+			return $providers;
+		}
+
+		// Bail early if the version is less than 1.1.1.
+		$progress_planner_version = \get_file_data( PROGRESS_PLANNER_FILE, [ 'Version' => 'Version' ] )['Version'];
+		if ( \version_compare( $progress_planner_version, '1.1.1', '<' ) ) {
+			return $providers;
+		}
+
 		// Remove the disable-comments provider - if you have this plugin installed, you don't need to see this task.
 		foreach ( $providers as $key => $provider ) {
 			if ( $provider->get_provider_id() === 'disable-comments' ) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,7 @@ parameters:
   treatPhpDocTypesAsCertain: false
   ignoreErrors:
     - '#Constant EMILIA_COMMENT_HACKS_PATH not found.#'
+    - '#Constant PROGRESS_PLANNER_FILE not found.#'
     - '#Call to an undefined method EmiliaProjects\\WP\\Comment\\Inc\\Progress_Planner\\[a-zA-Z0-9_\\\:\(\)].#'
     - '#Call to method [a-zA-Z0-9_\\\]+() on an unknown class Progress_Planner\\[a-zA-Z0-9_\\].#'
     - '#Method EmiliaProjects\\WP\\Comment\\Inc\\Progress_Planner_Tasks\:\:add_task_providers\(\) has invalid return type Progress_Planner\\Suggested_Tasks\\Local_Tasks\\Providers\\Provider.#'


### PR DESCRIPTION
In v1.1.1 of progress-planner we changed the structure of providers, and some things are not backwards-compatible.
This PR adds a check to avoid adding providers if the PP version is older than 1.1.1 in order to avoid conflicts and PHP errors in case the user updates comment-experience before updating progress-planner