### PR TITLE
Fix links for Progress Planner tasks

### DIFF
--- a/inc/progress-planner/comment-policy.php
+++ b/inc/progress-planner/comment-policy.php
@@ -51,7 +51,7 @@ class Comment_Policy extends One_Time {
 			\esc_html__( 'Implement a %s to make sure your commenters know what they can and cannot do.', 'comment-hacks' ),
 			'<a href="https://prpl.fyi/comment-policy" target="_blank">' . \esc_html__( 'comment policy', 'comment-hacks' ) . '</a>'
 		);
-		$this->url = \admin_url( 'options-general.php?page=comment-policy#top#comment-policy' );
+		$this->url = \admin_url( 'options-general.php?page=comment-experience#top#comment-policy' );
 	}
 
 	/**

--- a/inc/progress-planner/comment-redirect.php
+++ b/inc/progress-planner/comment-redirect.php
@@ -51,7 +51,7 @@ class Comment_Redirect extends One_Time {
 			\esc_html__( 'Implement a %s to thank first-time commenters for their comment.', 'comment-hacks' ),
 			'<a href="https://prpl.fyi/comment-policy" target="_blank">' . \esc_html__( 'comment redirect', 'comment-hacks' ) . '</a>'
 		);
-		$this->url = \admin_url( 'options-general.php?page=comment-policy#top#comment-redirect' );
+		$this->url = \admin_url( 'options-general.php?page=comment-experience#top#comment-redirect' );
 	}
 
 	/**


### PR DESCRIPTION
## Context

Links are [mistakenly change](https://github.com/ProgressPlanner/comment-hacks/commit/bda0e4c8809ea81c40b3a2dafb0fee26455835ae) when changes for v2.1.2 were merged.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
