### PR TITLE
Delay translatable strings

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -39,7 +39,9 @@ class Admin {
 	 * Class constructor.
 	 */
 	public function __construct() {
-		$this->options = Hacks::get_options();
+
+		// Set the options on init, since they have translatable strings.
+		\add_action( 'init', [ $this, 'set_options' ], 1, 1 );
 
 		// Hook into init for registration of the option and the language files.
 		\add_action( 'admin_init', [ $this, 'init' ] );
@@ -62,6 +64,15 @@ class Admin {
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_discussion_settings_script' ] );
 
 		new Comment_Parent();
+	}
+
+	/**
+	 * Set the options on init, since they have translatable strings.
+	 *
+	 * @return void
+	 */
+	public function set_options() {
+		$this->options = Hacks::get_options();
 	}
 
 	/**

--- a/inc/forms.php
+++ b/inc/forms.php
@@ -18,6 +18,17 @@ class Forms {
 	 * Class constructor.
 	 */
 	public function __construct() {
+
+		// Delay to init, since the options have translatable strings.
+		\add_action( 'init', [ $this, 'init' ], 1, 1 );
+	}
+
+	/**
+	 * Initialize Forms.
+	 *
+	 * @return void
+	 */
+	public function init() {
 		$this->options = Hacks::get_options();
 		Hacks::get_defaults();
 

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -26,11 +26,9 @@ class Hacks {
 	 * Class constructor.
 	 */
 	public function __construct() {
-		$this->options = self::get_options();
-		if ( ! isset( $this->options['version'] ) || \EMILIA_COMMENT_HACKS_VERSION > $this->options['version'] ) {
-			$this->set_defaults();
-			$this->upgrade();
-		}
+
+		// On init since option defaults have translatable strings.
+		\add_action( 'init', [ $this, 'init' ], 0, 1 );
 
 		\add_action( 'init', [ $this, 'load_text_domain' ] );
 
@@ -47,10 +45,6 @@ class Hacks {
 
 		\add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_comment_block_scripts' ] );
 
-		if ( $this->options['clean_emails'] ) {
-			new Clean_Emails();
-		}
-
 		if ( \is_admin() || \wp_doing_ajax() ) {
 			new Admin();
 		}
@@ -60,6 +54,23 @@ class Hacks {
 		new Forms();
 		new Length();
 		new Progress_Planner_Tasks();
+	}
+
+	/**
+	 * Initialize the comment hacks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		$this->options = self::get_options();
+		if ( ! isset( $this->options['version'] ) || \EMILIA_COMMENT_HACKS_VERSION > $this->options['version'] ) {
+			$this->set_defaults();
+			$this->upgrade();
+		}
+
+		if ( $this->options['clean_emails'] ) {
+			new Clean_Emails();
+		}
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -59,6 +59,10 @@ If you have bugs to report, please go to [the plugin's GitHub repository](https:
 
 == Changelog ==
 
+= 2.1.4 =
+
+* Add necessary compatibility for the upcoming WordPress 6.8.
+
 = 2.1.3 =
 
 * Add necessary compatibility to Progress Planner integration for the upcoming WordPress 6.8.

--- a/readme.txt
+++ b/readme.txt
@@ -61,7 +61,7 @@ If you have bugs to report, please go to [the plugin's GitHub repository](https:
 
 = 2.1.4 =
 
-* Add necessary compatibility for the upcoming WordPress 6.8.
+* Add compatibility with WordPress 6.8.
 
 = 2.1.3 =
 


### PR DESCRIPTION
## Context

Similar to the https://github.com/ProgressPlanner/comment-hacks/pull/145 , translatable strings which are added as the Options defaults are set to early.

This PR delays all calls to the `Hacks::get_defaults` to the `init` hook.
