### PR TITLE
Fix invalid redirect url when default options are saved

### DIFF
--- a/admin/views/config-page.php
+++ b/admin/views/config-page.php
@@ -280,7 +280,7 @@ use EmiliaProjects\WP\Comment\Inc\Hacks;
 									'id'                => 'redirect_page',
 									// phpcs:ignore WordPress.Security.EscapeOutput -- This is a hard-coded string, just passed around as a variable.
 									'name'              => Hacks::$option_name . '[redirect_page]',
-									'option_none_value' => '',
+									'option_none_value' => '0',
 									'selected'          => ( isset( $this->options['redirect_page'] ) ? (int) $this->options['redirect_page'] : 0 ),
 									'show_option_none'  => esc_html__( 'Don\'t redirect first time commenters', 'comment-hacks' ),
 								]
@@ -318,7 +318,7 @@ use EmiliaProjects\WP\Comment\Inc\Hacks;
 									'id'                => 'redirect_repeat_page',
 									// phpcs:ignore WordPress.Security.EscapeOutput -- This is a hard-coded string, just passed around as a variable.
 									'name'              => Hacks::$option_name . '[redirect_repeat_page]',
-									'option_none_value' => '',
+									'option_none_value' => '0',
 									'selected'          => ( isset( $this->options['redirect_repeat_page'] ) ? (int) $this->options['redirect_repeat_page'] : 0 ),
 									'show_option_none'  => esc_html__( 'Don\'t redirect repeat commenters', 'comment-hacks' ),
 								]

--- a/admin/views/config-page.php
+++ b/admin/views/config-page.php
@@ -158,7 +158,7 @@ use EmiliaProjects\WP\Comment\Inc\Hacks;
 									'name'              => esc_attr( Hacks::$option_name . '[comment_policy_page]' ),
 									'id'                => 'comment_policy_page',
 									'show_option_none'  => esc_html__( 'Select comment policy page', 'comment-hacks' ),
-									'option_none_value' => '',
+									'option_none_value' => '0',
 								]
 							);
 							?>
@@ -287,7 +287,7 @@ use EmiliaProjects\WP\Comment\Inc\Hacks;
 							);
 							?>
 
-							<?php if ( isset( $this->options['redirect_page'] ) && $this->options['redirect_page'] !== 0 ) : ?>
+							<?php if ( isset( $this->options['redirect_page'] ) && (int) $this->options['redirect_page'] !== 0 ) : ?>
 								<br>
 								<br>
 								<a target="_blank" href="<?php echo esc_url( get_permalink( (int) $this->options['redirect_page'] ) ); ?>">
@@ -352,7 +352,7 @@ use EmiliaProjects\WP\Comment\Inc\Hacks;
 								type="checkbox"
 								id="clean_emails"
 								name="<?php echo esc_attr( Hacks::$option_name . '[clean_emails]' ); ?>"
-								<?php checked( $this->options['clean_emails'] ); ?> 
+								<?php checked( $this->options['clean_emails'] ); ?>
 							/>
 						</td>
 					</tr>

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -225,7 +225,7 @@ class Hacks {
 		// If no approved comments have been found, show the thank-you page.
 		if ( empty( $has_approved_comment ) ) {
 			// Only change $url when the page option is actually set and not zero.
-			if ( isset( $this->options['redirect_page'] ) && $this->options['redirect_page'] !== 0 ) {
+			if ( isset( $this->options['redirect_page'] ) && (int) $this->options['redirect_page'] !== 0 ) {
 				$url = \get_permalink( (int) $this->options['redirect_page'] );
 
 				/**
@@ -243,7 +243,7 @@ class Hacks {
 		}
 
 		// Only change $url when the page option is actually set and not zero.
-		if ( isset( $this->options['redirect_repeat_page'] ) && $this->options['redirect_repeat_page'] !== 0 ) {
+		if ( isset( $this->options['redirect_repeat_page'] ) && (int) $this->options['redirect_repeat_page'] !== 0 ) {
 			$url = \get_permalink( (int) $this->options['redirect_repeat_page'] );
 
 			/**

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -319,7 +319,7 @@ class Hacks {
 			'comment_policy'               => false,
 			'comment_policy_text'          => \__( 'I agree to the comment policy.', 'comment-hacks' ),
 			'comment_policy_error'         => \__( 'You have to agree to the comment policy.', 'comment-hacks' ),
-			'comment_policy_page'          => 0,
+			'comment_policy_page'          => '0',
 			'disable_email_all_commenters' => false,
 			/* translators: %s expands to the post title */
 			'email_subject'                => \sprintf( \__( 'RE: %s', 'comment-hacks' ), '%title%' ),
@@ -331,7 +331,7 @@ class Hacks {
 			'mincomlengtherror'            => \__( 'Error: Your comment is too short. Please try to say something useful.', 'comment-hacks' ),
 			'maxcomlength'                 => 1500,
 			'maxcomlengtherror'            => \__( 'Error: Your comment is too long. Please try to be more concise.', 'comment-hacks' ),
-			'redirect_page'                => 0,
+			'redirect_page'                => '0',
 			'forward_email'                => '',
 			'forward_name'                 => \__( 'Support', 'comment-hacks' ),
 			/* translators: %1$s is replaced by the blog's name. */

--- a/inc/progress-planner/comment-policy.php
+++ b/inc/progress-planner/comment-policy.php
@@ -77,7 +77,7 @@ class Comment_Policy extends One_Time {
 	 * @return bool
 	 */
 	public function should_add_task() {
-		if ( ! $this->options['comment_policy_page'] || ! $this->options['comment_policy'] ) {
+		if ( ! (int) $this->options['comment_policy_page'] || ! (int) $this->options['comment_policy'] ) {
 			return true;
 		}
 


### PR DESCRIPTION
## Context

When plugin is activated and it's options are saved (without changing any of them) user will get a blank page upon submitting new comment.

<details><summary>Video probably explains it better</summary>
https://github.com/user-attachments/assets/ec5ca92c-91af-4b7d-a6e0-0fbe39c80fce
</details>


This PR fixes that by setting default value for empty selection for Comment redirect pages and also it casts values where needed, to be sure we're always working with integers.
