### PR TITLE
Add allowed comment length note above the comment textarea

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -349,6 +349,7 @@ To: ' . \esc_html( \get_bloginfo( 'name' ) ) . ' &lt;' . \esc_html( $this->optio
 				case 'comment_policy':
 				case 'clean_emails':
 				case 'disable_email_all_commenters':
+				case 'allowed_com_length_note_show':
 					$input[ $key ] = $this->sanitize_bool( $value );
 					break;
 				case 'email_subject':
@@ -356,6 +357,7 @@ To: ' . \esc_html( \get_bloginfo( 'name' ) ) . ' &lt;' . \esc_html( $this->optio
 				case 'mass_email_body':
 				case 'forward_name':
 				case 'forward_subject':
+				case 'allowed_com_length_note_text':
 					$input[ $key ] = $this->sanitize_string( $value, $defaults[ $key ] );
 					break;
 				case 'forward_email':

--- a/admin/views/config-page.php
+++ b/admin/views/config-page.php
@@ -116,6 +116,42 @@ use EmiliaProjects\WP\Comment\Inc\Hacks;
 						</td>
 					</tr>
 				</table>
+
+				<h3><?php esc_html_e( 'Display note about comment length above comment textarea', 'comment-hacks' ); ?></h3>
+
+				<p><?php esc_html_e( 'Display a note above the comment textarea to inform users about the allowed comment length.', 'comment-hacks' ); ?></p>
+				<table class="form-table">
+					<tr>
+						<th scope="row">
+							<label for="allowed_com_length_note_show">
+								<?php esc_html_e( 'Display note', 'comment-hacks' ); ?>
+							</label>
+						</th>
+						<td>
+							<input
+								type="checkbox"
+								id="allowed_com_length_note_show"
+								name="<?php echo esc_attr( Hacks::$option_name . '[allowed_com_length_note_show]' ); ?>"
+								<?php checked( $this->options['allowed_com_length_note_show'] ); ?>
+							/>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">
+							<label for="allowed_com_length_note_text">
+								<?php esc_html_e( 'Note text', 'comment-hacks' ); ?>
+							</label>
+						</th>
+						<td>
+							<textarea
+								rows="4"
+								cols="80"
+								name="<?php echo esc_attr( Hacks::$option_name . '[allowed_com_length_note_text]' ); ?>"
+								id="allowedcomnote"
+							><?php echo esc_textarea( $this->options['allowed_com_length_note_text'] ); ?></textarea>
+						</td>
+					</tr>
+				</table>
 			</div>
 
 			<div id="comment-policy" class="emiliaprojectstab">
@@ -352,7 +388,7 @@ use EmiliaProjects\WP\Comment\Inc\Hacks;
 								type="checkbox"
 								id="clean_emails"
 								name="<?php echo esc_attr( Hacks::$option_name . '[clean_emails]' ); ?>"
-								<?php checked( $this->options['clean_emails'] ); ?> 
+								<?php checked( $this->options['clean_emails'] ); ?>
 							/>
 						</td>
 					</tr>

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -331,6 +331,9 @@ class Hacks {
 			'mincomlengtherror'            => \__( 'Error: Your comment is too short. Please try to say something useful.', 'comment-hacks' ),
 			'maxcomlength'                 => 1500,
 			'maxcomlengtherror'            => \__( 'Error: Your comment is too long. Please try to be more concise.', 'comment-hacks' ),
+			'allowed_com_length_note_show' => false,
+			/* translators: %1$s is replaced with the minimum number of characters, %2$s with the maximum number of characters */
+			'allowed_com_length_note_text' => \sprintf( \__( 'Allowed comment length is between %1$s and %2$s characters.', 'comment-hacks' ), '%mincomlength%', '%maxcomlength%' ),
 			'redirect_page'                => 0,
 			'forward_email'                => '',
 			'forward_name'                 => \__( 'Support', 'comment-hacks' ),

--- a/inc/length.php
+++ b/inc/length.php
@@ -80,13 +80,17 @@ class Length {
 	/**
 	 * Adds a message to the comment form for the allowed comment length.
 	 *
-	 * @return void
+	 * @since 2.1.4
+	 *
+	 * @param string $field The comment form field.
+	 *
+	 * @return string The comment form field.
 	 */
 	public function allowed_comment_length_note( $field ) {
 
 		if ( $this->options['allowed_com_length_note_show'] ) {
-			$note = \str_replace( '%mincomlength%', $this->options['mincomlength'], $this->options['allowed_com_length_note_text'] );
-			$note = \str_replace( '%maxcomlength%', $this->options['maxcomlength'], $note );
+			$note  = \str_replace( '%mincomlength%', $this->options['mincomlength'], $this->options['allowed_com_length_note_text'] );
+			$note  = \str_replace( '%maxcomlength%', $this->options['maxcomlength'], $note );
 			$field = '<label class="comment-hacks-allowed-comment-length-note">' . \esc_html( $note ) . '</label>' . $field;
 		}
 

--- a/inc/length.php
+++ b/inc/length.php
@@ -22,6 +22,9 @@ class Length {
 
 		// Process the comment and check it for length.
 		\add_filter( 'preprocess_comment', [ $this, 'check_comment_length' ] );
+
+		// Add a message to the comment form, before the comment textarea, to inform the user about the allowed comment length.
+		\add_filter( 'comment_form_field_comment', [ $this, 'allowed_comment_length_note' ], 99 );
 	}
 
 	/**
@@ -72,5 +75,21 @@ class Length {
 			return \mb_strlen( $comment, \get_bloginfo( 'charset' ) );
 		}
 		return \strlen( $comment );
+	}
+
+	/**
+	 * Adds a message to the comment form for the allowed comment length.
+	 *
+	 * @return void
+	 */
+	public function allowed_comment_length_note( $field ) {
+
+		if ( $this->options['allowed_com_length_note_show'] ) {
+			$note = \str_replace( '%mincomlength%', $this->options['mincomlength'], $this->options['allowed_com_length_note_text'] );
+			$note = \str_replace( '%maxcomlength%', $this->options['maxcomlength'], $note );
+			$field = '<label class="comment-hacks-allowed-comment-length-note">' . \esc_html( $note ) . '</label>' . $field;
+		}
+
+		return $field;
 	}
 }


### PR DESCRIPTION
## Context

This PR adds a note about allowed comment length above the comment textarea field
<details>
<summary>Screenshot</summary>
<img width="736" alt="Screenshot 2025-04-09 at 17 35 29" src="https://github.com/user-attachments/assets/2f3b7854-d990-40df-894e-10f099931a41" />
</details>

Settings on the Config page are also added, which allow user to disable the note (default) and to customize it:
<details>
<summary>Screenshot</summary>
<img width="947" alt="Screenshot 2025-04-09 at 17 38 33" src="https://github.com/user-attachments/assets/296f93a0-da00-4a33-a1f0-c78d9505e7ba" />

</details>

Based from the [.org review](https://wordpress.org/support/topic/doesnt-warn-commenter/)

**NOTE:**
It needs a bit more testing, updating plugin specifically.

