### PR TITLE
Run upgrade routine only when plugin version is increased

### DIFF
--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -311,7 +311,7 @@ class Hacks {
 
 		if ( ! isset( $this->options['disable_email_all_commenters'] ) ) {
 			$this->options['disable_email_all_commenters'] = false;
-			$options_changed = true;
+			$options_changed                               = true;
 		}
 
 		if ( $options_changed ) {

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -284,6 +284,8 @@ class Hacks {
 	 * @return void
 	 */
 	private function upgrade(): void {
+		$options_changed = false;
+
 		foreach ( [ 'MinComLengthOptions', 'min_comment_length_option', 'CommentRedirect' ] as $old_option ) {
 			$old_option_values = $this->get_option_from_cache( $old_option );
 			if ( \is_array( $old_option_values ) ) {
@@ -293,19 +295,28 @@ class Hacks {
 				}
 				$this->options = \wp_parse_args( $this->options, $old_option_values );
 				\delete_option( $old_option );
+				$options_changed = true;
 			}
 		}
 
 		if ( ! isset( $this->options['version'] ) ) {
 			$this->options['clean_emails'] = true;
-			$this->options['version']      = \EMILIA_COMMENT_HACKS_VERSION;
+			$options_changed = true;
+		}
+
+		if ( ! isset( $this->options['version'] ) || \EMILIA_COMMENT_HACKS_VERSION > $this->options['version'] ) {
+			$this->options['version'] = \EMILIA_COMMENT_HACKS_VERSION;
+			$options_changed = true;
 		}
 
 		if ( ! isset( $this->options['disable_email_all_commenters'] ) ) {
 			$this->options['disable_email_all_commenters'] = false;
+			$options_changed = true;
 		}
 
-		\update_option( self::$option_name, $this->options );
+		if ( $options_changed ) {
+			\update_option( self::$option_name, $this->options );
+		}
 	}
 
 	/**

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -301,12 +301,12 @@ class Hacks {
 
 		if ( ! isset( $this->options['version'] ) ) {
 			$this->options['clean_emails'] = true;
-			$options_changed = true;
+			$options_changed               = true;
 		}
 
 		if ( ! isset( $this->options['version'] ) || \EMILIA_COMMENT_HACKS_VERSION > $this->options['version'] ) {
 			$this->options['version'] = \EMILIA_COMMENT_HACKS_VERSION;
-			$options_changed = true;
+			$options_changed          = true;
 		}
 
 		if ( ! isset( $this->options['disable_email_all_commenters'] ) ) {


### PR DESCRIPTION
Plugin [sets defaults & runs upgrade method](https://github.com/ProgressPlanner/comment-hacks/blob/366d7e725213afa1951778deaccab7a620f9f1e8/inc/hacks.php#L30) if the version is not set or it's lower than then defined in the main plugin file.

But then in the upgrade method it [sets the version](https://github.com/ProgressPlanner/comment-hacks/blob/366d7e725213afa1951778deaccab7a620f9f1e8/inc/hacks.php#L299) only if it is not previously set.
Meaning that once plugin is updated to the next version it will run set_defaults & upgrade on every page load.

This PR fixes that and runs the upgrade routine only when plugin version is increased.