### PR TITLE
Compatibility with the upcoming Progress Planner v1.4

### DIFF
--- a/inc/progress-planner-tasks.php
+++ b/inc/progress-planner-tasks.php
@@ -30,6 +30,11 @@ class Progress_Planner_Tasks {
 			return $providers;
 		}
 
+		// Bail early if the Tasks class does not exist.
+		if ( ! \class_exists( '\Progress_Planner\Suggested_Tasks\Providers\Tasks' ) ) {
+			return $providers;
+		}
+
 		// Remove the disable-comments provider - if you have this plugin installed, you don't need to see this task.
 		foreach ( $providers as $key => $provider ) {
 			if ( $provider->get_provider_id() === 'disable-comments' ) {

--- a/inc/progress-planner-tasks.php
+++ b/inc/progress-planner-tasks.php
@@ -2,7 +2,7 @@
 
 namespace EmiliaProjects\WP\Comment\Inc;
 
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Provider;
+use Progress_Planner\Suggested_Tasks\Tasks\Providers\Provider;
 
 /**
  * Registers the tasks for the Progress Planner.

--- a/inc/progress-planner/comment-moderation.php
+++ b/inc/progress-planner/comment-moderation.php
@@ -4,6 +4,9 @@ namespace EmiliaProjects\WP\Comment\Inc\Progress_Planner;
 
 use Progress_Planner\Suggested_Tasks\Providers\Tasks;
 
+if ( ! \class_exists( '\Progress_Planner\Suggested_Tasks\Providers\Tasks' ) ) {
+	return;
+}
 
 /**
  * Task for the comment moderation.

--- a/inc/progress-planner/comment-moderation.php
+++ b/inc/progress-planner/comment-moderation.php
@@ -2,18 +2,15 @@
 
 namespace EmiliaProjects\WP\Comment\Inc\Progress_Planner;
 
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Repetitive;
+use Progress_Planner\Suggested_Tasks\Providers\Tasks;
 
-if ( ! \class_exists( '\Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Repetitive' ) ) {
-	return;
-}
 
 /**
  * Task for the comment moderation.
  *
  * @property string $url
  */
-class Comment_Moderation extends Repetitive {
+class Comment_Moderation extends Tasks {
 
 	/**
 	 * The provider ID.
@@ -35,6 +32,13 @@ class Comment_Moderation extends Repetitive {
 	 * @var string
 	 */
 	protected const CAPABILITY = 'moderate_comments';
+
+	/**
+	 * Whether the task is repetitive.
+	 *
+	 * @var bool
+	 */
+	protected $is_repetitive = true;
 
 	/**
 	 * Constructor.

--- a/inc/progress-planner/comment-policy.php
+++ b/inc/progress-planner/comment-policy.php
@@ -5,6 +5,10 @@ namespace EmiliaProjects\WP\Comment\Inc\Progress_Planner;
 use EmiliaProjects\WP\Comment\Inc\Hacks;
 use Progress_Planner\Suggested_Tasks\Providers\Tasks;
 
+if ( ! \class_exists( '\Progress_Planner\Suggested_Tasks\Providers\Tasks' ) ) {
+	return;
+}
+
 
 /**
  * Task for the comment policy.

--- a/inc/progress-planner/comment-policy.php
+++ b/inc/progress-planner/comment-policy.php
@@ -3,18 +3,15 @@
 namespace EmiliaProjects\WP\Comment\Inc\Progress_Planner;
 
 use EmiliaProjects\WP\Comment\Inc\Hacks;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
+use Progress_Planner\Suggested_Tasks\Providers\Tasks;
 
-if ( ! \class_exists( '\Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time' ) ) {
-	return;
-}
 
 /**
  * Task for the comment policy.
  *
  * @property string $url
  */
-class Comment_Policy extends One_Time {
+class Comment_Policy extends Tasks {
 
 	/**
 	 * The provider ID.

--- a/inc/progress-planner/comment-redirect.php
+++ b/inc/progress-planner/comment-redirect.php
@@ -5,6 +5,10 @@ namespace EmiliaProjects\WP\Comment\Inc\Progress_Planner;
 use EmiliaProjects\WP\Comment\Inc\Hacks;
 use Progress_Planner\Suggested_Tasks\Providers\Tasks;
 
+if ( ! \class_exists( '\Progress_Planner\Suggested_Tasks\Providers\Tasks' ) ) {
+	return;
+}
+
 /**
  * Task for the comment redirect.
  *

--- a/inc/progress-planner/comment-redirect.php
+++ b/inc/progress-planner/comment-redirect.php
@@ -3,18 +3,14 @@
 namespace EmiliaProjects\WP\Comment\Inc\Progress_Planner;
 
 use EmiliaProjects\WP\Comment\Inc\Hacks;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time;
-
-if ( ! \class_exists( '\Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\One_Time' ) ) {
-	return;
-}
+use Progress_Planner\Suggested_Tasks\Providers\Tasks;
 
 /**
  * Task for the comment redirect.
  *
  * @property string $url
  */
-class Comment_Redirect extends One_Time {
+class Comment_Redirect extends Tasks {
 
 	/**
 	 * The provider ID.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,5 +12,5 @@ parameters:
     - '#Constant PROGRESS_PLANNER_FILE not found.#'
     - '#Call to an undefined method EmiliaProjects\\WP\\Comment\\Inc\\Progress_Planner\\[a-zA-Z0-9_\\\:\(\)].#'
     - '#Call to method [a-zA-Z0-9_\\\]+() on an unknown class Progress_Planner\\[a-zA-Z0-9_\\].#'
-    - '#Method EmiliaProjects\\WP\\Comment\\Inc\\Progress_Planner_Tasks\:\:add_task_providers\(\) has invalid return type Progress_Planner\\Suggested_Tasks\\Local_Tasks\\Providers\\Provider.#'
-    - '#Parameter \$providers of method EmiliaProjects\\WP\\Comment\\Inc\\Progress_Planner_Tasks\:\:add_task_providers\(\) has invalid type Progress_Planner\\Suggested_Tasks\\Local_Tasks\\Providers\\Provider.#'
+    - '#Method EmiliaProjects\\WP\\Comment\\Inc\\Progress_Planner_Tasks\:\:add_task_providers\(\) has invalid return type Progress_Planner\\Suggested_Tasks\\Tasks\\Providers\\Provider.#'
+    - '#Parameter \$providers of method EmiliaProjects\\WP\\Comment\\Inc\\Progress_Planner_Tasks\:\:add_task_providers\(\) has invalid type Progress_Planner\\Suggested_Tasks\\Tasks\\Providers\\Provider.#'


### PR DESCRIPTION
## Context
This PR makes plugin compatible with the Progress Planner v1.4.

Besides the PHP deprecation notices, because of the classes structure changed, it triggered the fatal error as well.
Reason is that we had this check inside the class file:
```
if ( ! \class_exists( '\Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Repetitive' ) ) {
	return;
}
```

So the class gets instantiated, autoloader loads the file but then there is an early exit - which triggers PHP fatal error since instantiated class is not defined.

For the reason I have moved the check the filter itself, so it's checked at once for all the tasks.
