### PR TITLE
Fix version constant mismatch causing upgrade on every page load

### DIFF
--- a/comment-hacks.php
+++ b/comment-hacks.php
@@ -36,7 +36,7 @@ use EmiliaProjects\WP\Comment\Inc\Hacks;
 /**
  * Used for version checks.
  */
-define( 'EMILIA_COMMENT_HACKS_VERSION', '2.1.6' );
+define( 'EMILIA_COMMENT_HACKS_VERSION', '2.1.7' );
 
 /**
  * Used for asset embedding.


### PR DESCRIPTION
## Summary
- The `EMILIA_COMMENT_HACKS_VERSION` constant was `2.1.6` while the plugin header declared `2.1.7`
- This caused `Hacks::init()` to run `set_defaults()` and `upgrade()` on **every single page load** because the version check never matched
- Fixed by syncing the constant to `2.1.7`

## Test plan
- [ ] Verify upgrade routine only runs once after update, not on every page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)