### PR TITLE
Fix repeat redirect overriding first-time commenter redirect

### DIFF
--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -249,10 +249,8 @@ class Hacks {
 				 */
 				$url = \apply_filters( 'comment_experience\redirect', $url, $comment, 'first' );
 			}
-		}
-
-		// Only change $url when the page option is actually set and not zero.
-		if ( isset( $this->options['redirect_repeat_page'] ) && (int) $this->options['redirect_repeat_page'] !== 0 ) {
+		} elseif ( isset( $this->options['redirect_repeat_page'] ) && (int) $this->options['redirect_repeat_page'] !== 0 ) {
+			// Only change $url when the page option is actually set and not zero.
 			$url = \get_permalink( (int) $this->options['redirect_repeat_page'] );
 
 			/**

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -249,8 +249,9 @@ class Hacks {
 				 */
 				$url = \apply_filters( 'comment_experience\redirect', $url, $comment, 'first' );
 			}
-		} elseif ( isset( $this->options['redirect_repeat_page'] ) && (int) $this->options['redirect_repeat_page'] !== 0 ) {
-			// Only change $url when the page option is actually set and not zero.
+		}
+		// Only change $url when the page option is actually set and not zero.
+		elseif ( isset( $this->options['redirect_repeat_page'] ) && (int) $this->options['redirect_repeat_page'] !== 0 ) {
 			$url = \get_permalink( (int) $this->options['redirect_repeat_page'] );
 
 			/**


### PR DESCRIPTION
## Summary
- The repeat-redirect block ran unconditionally, always overwriting the first-time redirect
- When both `redirect_page` and `redirect_repeat_page` were configured, first-time commenters would incorrectly get the repeat redirect
- Fixed by making the repeat redirect an `elseif` so it only applies to repeat commenters

## Test plan
- [ ] Configure both a first-time redirect page and a repeat redirect page
- [ ] Submit a comment as a first-time commenter — should redirect to the first-time page
- [ ] Submit a comment as a repeat commenter — should redirect to the repeat page

🤖 Generated with [Claude Code](https://claude.com/claude-code)