### PR TITLE
Fix get_option_from_cache returning key instead of value

### DIFF
--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -282,7 +282,7 @@ class Hacks {
 	 */
 	private function get_option_from_cache( string $option ) {
 		$options = \wp_load_alloptions();
-		return isset( $options[ $option ] ) ? $option : false;
+		return isset( $options[ $option ] ) ? $options[ $option ] : false;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- `get_option_from_cache()` returned `$option` (the key name) instead of `$options[$option]` (the value)
- This made the `is_array()` check in `upgrade()` always false, so legacy options from pre-1.0 (`MinComLengthOptions`, `min_comment_length_option`, `CommentRedirect`) were never migrated
- Fixed by returning `$options[$option]`

## Test plan
- [ ] If any ancient pre-1.0 installations exist with old option names, they would now be migrated correctly
- [ ] For modern installations this is a no-op since those old options don't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)