### PR TITLE
Fix comment type check missing empty string in email formatting

### DIFF
--- a/inc/clean-emails.php
+++ b/inc/clean-emails.php
@@ -176,7 +176,7 @@ class Clean_Emails {
 	 * @return void
 	 */
 	private function add_author_line(): void {
-		if ( $this->comment->comment_type === 'comment' ) {
+		if ( $this->comment->comment_type !== 'pingback' && $this->comment->comment_type !== 'trackback' ) {
 			/* translators: %1$s is replaced with the comment author's name, %2$s is replaced with the comment author's email */
 			$this->message .= \sprintf( \esc_html__( 'Author: %1$s (%2$s)', 'yoast-comment-hacks' ), \esc_html( $this->comment->comment_author ), '<a href="' . \esc_url( 'mailto:' . $this->comment->comment_author_email ) . '">' . \esc_html( $this->comment->comment_author_email ) . '</a>' ) . '<br />';
 		}
@@ -192,7 +192,7 @@ class Clean_Emails {
 	 * @return void
 	 */
 	private function add_content_line(): void {
-		if ( $this->comment->comment_type === 'comment' ) {
+		if ( $this->comment->comment_type !== 'pingback' && $this->comment->comment_type !== 'trackback' ) {
 			$this->message .= \esc_html__( 'Comment:', 'yoast-comment-hacks' );
 		}
 		else {


### PR DESCRIPTION
## Summary
- WordPress stores `comment_type` as either `''` (empty string) or `'comment'` for regular comments
- The `=== 'comment'` strict comparison in `add_author_line()` and `add_content_line()` missed the empty string case
- Regular comments with empty `comment_type` were formatted as pingbacks/trackbacks in notification emails (showing "Website:" instead of "Author:" and "Excerpt:" instead of "Comment:")
- Fixed by checking against known non-comment types (`pingback`/`trackback`) instead, matching the approach used in the switch statements elsewhere in the same class

## Test plan
- [ ] Submit a regular comment and verify the notification email shows "Author:" and "Comment:" labels
- [ ] Submit/receive a pingback and verify the email shows "Website:" and "Excerpt:" labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)