### PR TITLE
Simplify redundant code patterns across codebase

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -401,7 +401,7 @@ To: ' . \esc_html( \get_bloginfo( 'name' ) ) . ' &lt;' . \esc_html( $this->optio
 	 * @return bool
 	 */
 	private function sanitize_bool( $value ): bool {
-		return ( $value || ! empty( $value ) );
+		return (bool) $value;
 	}
 
 	/**

--- a/admin/comment-parent.php
+++ b/admin/comment-parent.php
@@ -33,18 +33,16 @@ class Comment_Parent {
 	 * @return void
 	 */
 	public function load_comment_parent_box() {
-		if ( \function_exists( 'add_meta_box' ) ) {
-			\add_meta_box(
-				'comment_parent',
-				\esc_html__( 'Comment Parent', 'yoast-comment-hacks' ),
-				[
-					$this,
-					'comment_parent_box',
-				],
-				'comment',
-				'normal'
-			);
-		}
+		\add_meta_box(
+			'comment_parent',
+			\esc_html__( 'Comment Parent', 'yoast-comment-hacks' ),
+			[
+				$this,
+				'comment_parent_box',
+			],
+			'comment',
+			'normal'
+		);
 	}
 
 	/**
@@ -65,11 +63,10 @@ class Comment_Parent {
 			return; // There might be another reason for a comment to be updated.
 		}
 
-		if ( \function_exists( 'wp_doing_ajax' ) && \wp_doing_ajax() ) {
+		if ( \wp_doing_ajax() ) {
 			\check_ajax_referer( 'replyto-comment', '_ajax_nonce-replyto-comment' );
 		}
-
-		if ( ! \function_exists( 'wp_doing_ajax' ) || ! \wp_doing_ajax() ) {
+		else {
 			\check_admin_referer( 'update-comment_' . $comment_id );
 		}
 

--- a/inc/clean-emails.php
+++ b/inc/clean-emails.php
@@ -299,14 +299,12 @@ class Clean_Emails {
 	 * @return void
 	 */
 	private function comment_action_links( array $actions ): void {
-		$links = '';
+		$links = [];
 		foreach ( $actions as $action => $label ) {
-			$links .= $this->comment_action_link( $label, $action ) . ' | ';
+			$links[] = $this->comment_action_link( $label, $action );
 		}
 
-		$links = \rtrim( $links, '| ' );
-
-		$this->message .= $links;
+		$this->message .= \implode( ' | ', $links );
 	}
 
 	/**

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -160,7 +160,7 @@ class Hacks {
 	public function get_remove_comment_url_link( $comment_id ) {
 		$comment = \get_comment( $comment_id );
 
-		if ( isset( $comment ) && $comment instanceof WP_Comment && ! empty( $comment->comment_author_url ) ) {
+		if ( $comment instanceof WP_Comment && ! empty( $comment->comment_author_url ) ) {
 			return \sprintf(
 				'<a href="#" class="comment-remove-url" data-comment-id="%d" aria-label="%s">%s</a>',
 				\esc_attr( (string) $comment_id ),

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -54,9 +54,7 @@ class Notifications {
 			return $message_headers;
 		}
 
-		$name = $comment->comment_author !== ''
-			? \esc_html( $comment->comment_author )
-			: $comment->comment_author_email;
+		$name = ( $comment->comment_author !== '' ) ? \esc_html( $comment->comment_author ) : $comment->comment_author_email;
 
 		$message_headers .= "\nReply-To: $name <$comment->comment_author_email>\n";
 

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -50,18 +50,15 @@ class Notifications {
 	public function filter_notification_headers( $message_headers, $comment_id ): string {
 		$comment = \get_comment( $comment_id );
 
-		if ( $comment->comment_author !== '' && $comment->comment_author_email !== '' ) {
-			$name             = \esc_html( $comment->comment_author );
-			$message_headers .= "\nReply-To: $name <$comment->comment_author_email>\n";
-
+		if ( $comment->comment_author_email === '' ) {
 			return $message_headers;
 		}
 
-		if ( $comment->comment_author_email !== '' ) {
-			$message_headers .= "\nReply-To: $comment->comment_author_email <$comment->comment_author_email>\n";
+		$name = $comment->comment_author !== ''
+			? \esc_html( $comment->comment_author )
+			: $comment->comment_author_email;
 
-			return $message_headers;
-		}
+		$message_headers .= "\nReply-To: $name <$comment->comment_author_email>\n";
 
 		return $message_headers;
 	}

--- a/inc/progress-planner/comment-policy.php
+++ b/inc/progress-planner/comment-policy.php
@@ -78,11 +78,7 @@ class Comment_Policy extends Tasks {
 	 * @return bool
 	 */
 	public function should_add_task() {
-		if ( ! (int) $this->options['comment_policy_page'] || ! (int) $this->options['comment_policy'] ) {
-			return true;
-		}
-
-		return false;
+		return ! (int) $this->options['comment_policy_page'] || ! (int) $this->options['comment_policy'];
 	}
 
 	/**

--- a/inc/progress-planner/comment-redirect.php
+++ b/inc/progress-planner/comment-redirect.php
@@ -77,11 +77,7 @@ class Comment_Redirect extends Tasks {
 	 * @return bool
 	 */
 	public function should_add_task() {
-		if ( ! $this->options['redirect_page'] ) {
-			return true;
-		}
-
-		return false;
+		return ! $this->options['redirect_page'];
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- **sanitize_bool** (`admin/admin.php`): `($value || !empty($value))` is equivalent to `(bool) $value`
- **function_exists checks** (`admin/comment-parent.php`): `add_meta_box` (WP 2.5+) and `wp_doing_ajax` (WP 4.7+) are guaranteed to exist
- **filter_notification_headers** (`inc/notifications.php`): two branches with duplicated header-append logic merged into one
- **comment_action_links** (`inc/clean-emails.php`): build-then-rtrim replaced with `implode`
- **should_add_task** (`inc/progress-planner/`): if/return true/return false simplified to direct boolean return
- **get_remove_comment_url_link** (`inc/hacks.php`): redundant `isset()` before `instanceof` removed

## Test plan
- [ ] Verify comment parent meta box still appears on comment edit screen
- [ ] Verify AJAX reply-to-comment and admin comment editing still work
- [ ] Verify notification emails still include Reply-To header
- [ ] Verify notification/moderation email action links render correctly
- [ ] Verify boolean options (comment policy, clean emails) save correctly from settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)