### PR TITLE
Remove unused $num variable in debug output

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -477,8 +477,7 @@ To: ' . \esc_html( \get_bloginfo( 'name' ) ) . ' &lt;' . \esc_html( $this->optio
 					'<code>',
 					'<code style="background-color: #eee; margin: 0; padding: 0;">',
 					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- This is only shown in debug mode.
-					\highlight_string( "<?php\n\$this->options = " . \var_export( $this->options, true ) . ';', true ),
-					$num
+					\highlight_string( "<?php\n\$this->options = " . \var_export( $this->options, true ) . ';', true )
 				);
 				?>
 			</div>


### PR DESCRIPTION
## Summary
- `str_replace()` in `Admin::config_page()` passed `$num` as the 4th argument (replacement count)
- `$num` was never declared and never read — it's a leftover from debugging
- Removed the unused argument

## Test plan
- [ ] Enable `WP_DEBUG` and visit the Comment Experience settings page — debug output should still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)