### PR TITLE
Remove unused Hacks::get_defaults() call in Forms::init

### DIFF
--- a/inc/forms.php
+++ b/inc/forms.php
@@ -30,7 +30,6 @@ class Forms {
 	 */
 	public function init() {
 		$this->options = Hacks::get_options();
-		Hacks::get_defaults();
 
 		if ( $this->options['comment_policy'] ) {
 			\add_action( 'comment_form_after_fields', [ $this, 'comment_form_fields' ] );


### PR DESCRIPTION
## Summary
- `Forms::init()` called `Hacks::get_defaults()` without capturing the return value
- `get_defaults()` is a pure function (builds and returns an array of defaults) with no side effects
- The call did nothing — removed it

## Test plan
- [ ] Verify comment policy checkbox still appears on comment form when enabled
- [ ] Verify comment policy validation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)