### PR TITLE
Fix plugin-check CI: pin dist-archive-command to ^3.1

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -18,7 +18,7 @@ jobs:
             tools: wp-cli
 
         - name: Install latest version of dist-archive-command
-          run: wp package install wp-cli/dist-archive-command:@stable
+          run: wp package install wp-cli/dist-archive-command:^3.1
 
         - name: Build plugin
           run: |


### PR DESCRIPTION
## Summary
- Pin `wp-cli/dist-archive-command` from `@stable` to `^3.1` to fix broken CI
- `@stable` started resolving to an incompatible version, breaking the plugin-check workflow

## Context
Same fix already applied to: brand-assets, pp-hosts, pp-glossary, progress-planner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)